### PR TITLE
change base directory for files in assemble

### DIFF
--- a/.s2i/assemble
+++ b/.s2i/assemble
@@ -1,16 +1,18 @@
 #!/bin/bash
 set -eo pipefail
 
+basedir=/opt/app-root
 # Copy files to correct location, as used by the base image
 
-cp -R /tmp/src/* /home/$NB_USER/work
+mkdir -p $basedir/work
+cp -R /tmp/src/* $basedir/work
 
-cd /home/$NB_USER/work
+cd $basedir/work
 
 echo MAKE TARGET LIST IS "${S2I_MAKE_TARGETS}"
 
 echo EXTRA REQUIREMENTS ARE:
-cat /home/$NB_USER/work/requirements.txt
+cat $basedir/work/requirements.txt
 
 ## install requirements
 


### PR DESCRIPTION
This change moves the base directory from `/home/$NB_USER/work` to
`/opt/app-root/work` in the assemble file. This is being added to avoid
permission issues in /home and to reduce requirements on specific user
names.